### PR TITLE
Clarify keys in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,10 +9,12 @@ A `ManyKeysWeakMap` object is identical to a regular `WeakMap`, which the except
 
 ```js
 const regularMap = new WeakMap();
-regularMap.set({}, true);
+const obj = {};
+regularMap.set(obj, true);
 
 const manyKeysWeakMap = new ManyKeysWeakMap();
-manyKeysWeakMap.set([{}, new Date()], true);
+const date = new Date();
+manyKeysWeakMap.set([obj, date], true);
 ```
 
 Or:
@@ -20,7 +22,8 @@ Or:
 ```js
 const handlers = new ManyKeysWeakMap();
 handlers.set([element, sub1], fn1);
-handlers.set([element, sub2, {passive: true}], fn2);
+const someOptions = {passive: true};
+handlers.set([element, sub2, someOptions], fn2);
 ```
 
 The number of keys allowed is unlimited and their order is relevant.


### PR DESCRIPTION
The objects passed as keys must be reusable, lines of code that contain objects that are thrown away immediately are redundant. This clarifies the readme to avoid misunderstandings for the readers.

When I initially wrote this, I wasn’t sure how it works if it’s passing `new Date` in. And `{passive: true}` looked like options to ManyKeysWeakMap, and I was wondering how it distinguishes the options object from an arbitrary key that looks like an options object.